### PR TITLE
fix: remove deprecated joypad pressure property

### DIFF
--- a/GodotTestDriver.Tests/ControllerInputExtensionsTest.cs
+++ b/GodotTestDriver.Tests/ControllerInputExtensionsTest.cs
@@ -77,17 +77,14 @@ public partial class ControllerInputExtensionsTest : DriverTest
         var testNode = new JoypadButtonInputEventTestNode();
         RootNode.AddChild(testNode);
         testNode.Events.Count.ShouldBe(0);
-        // Press controller device 1's X button with 80% pressure. Note that this doesn't correspond to
-        // actual functionality of common gamepads.
+        // Press controller device 1's X button.
         var button = JoyButton.X;
         var deviceID = 1;
-        var pressure = 0.8f;
-        testNode.PressJoypadButton(button, deviceID, pressure);
+        testNode.PressJoypadButton(button, deviceID);
         testNode.Events.Count.ShouldBe(1);
         testNode.Events[0].Event.Pressed.ShouldBeTrue();
         testNode.Events[0].Event.ButtonIndex.ShouldBe(button);
         testNode.Events[0].Event.Device.ShouldBe(deviceID);
-        testNode.Events[0].Event.Pressure.ShouldBe(pressure);
         RootNode.RemoveChild(testNode); // Remove immediately since we won't wait a frame for the free
         testNode.QueueFree();
     }
@@ -106,7 +103,6 @@ public partial class ControllerInputExtensionsTest : DriverTest
         testNode.Events[0].Event.Pressed.ShouldBeFalse();
         testNode.Events[0].Event.ButtonIndex.ShouldBe(button);
         testNode.Events[0].Event.Device.ShouldBe(deviceID);
-        testNode.Events[0].Event.Pressure.ShouldBe(0.0f);
         RootNode.RemoveChild(testNode); // Remove immediately since we won't wait a frame for the free
         testNode.QueueFree();
     }
@@ -117,21 +113,17 @@ public partial class ControllerInputExtensionsTest : DriverTest
         var testNode = new JoypadButtonInputEventTestNode();
         RootNode.AddChild(testNode);
         testNode.Events.Count.ShouldBe(0);
-        // Tap controller device 1's X button with 80% pressure. Note that this doesn't correspond to
-        // actual functionality of common gamepads.
+        // Tap controller device 1's X button.
         var button = JoyButton.X;
         var deviceID = 1;
-        var pressure = 0.8f;
-        testNode.TapJoypadButton(button, deviceID, pressure);
+        testNode.TapJoypadButton(button, deviceID);
         testNode.Events.Count.ShouldBe(2);
         testNode.Events[0].Event.Pressed.ShouldBeTrue();
         testNode.Events[0].Event.ButtonIndex.ShouldBe(button);
         testNode.Events[0].Event.Device.ShouldBe(deviceID);
-        testNode.Events[0].Event.Pressure.ShouldBe(pressure);
         testNode.Events[1].Event.Pressed.ShouldBeFalse();
         testNode.Events[1].Event.ButtonIndex.ShouldBe(button);
         testNode.Events[1].Event.Device.ShouldBe(deviceID);
-        testNode.Events[1].Event.Pressure.ShouldBe(0.0f);
         testNode.Events[1].ProcessFrame.ShouldBe(testNode.Events[0].ProcessFrame);
         RootNode.RemoveChild(testNode); // Remove immediately since we won't wait a frame for the free
         testNode.QueueFree();
@@ -143,23 +135,19 @@ public partial class ControllerInputExtensionsTest : DriverTest
         var testNode = new JoypadButtonInputEventTestNode();
         RootNode.AddChild(testNode);
         testNode.Events.Count.ShouldBe(0);
-        // Hold controller device 1's X button with 80% pressure for 2 seconds. Note that this doesn't correspond to
-        // actual functionality of common gamepads.
+        // Hold controller device 1's X button for 2 seconds.
         var button = JoyButton.X;
         var deviceID = 1;
-        var pressure = 0.8f;
         var seconds = 0.5f;
         var timeTolerance = 0.1f;
-        await testNode.HoldJoypadButtonFor(seconds, button, deviceID, pressure);
+        await testNode.HoldJoypadButtonFor(seconds, button, deviceID);
         testNode.Events.Count.ShouldBe(2);
         testNode.Events[0].Event.Pressed.ShouldBeTrue();
         testNode.Events[0].Event.ButtonIndex.ShouldBe(button);
         testNode.Events[0].Event.Device.ShouldBe(deviceID);
-        testNode.Events[0].Event.Pressure.ShouldBe(pressure);
         testNode.Events[1].Event.Pressed.ShouldBeFalse();
         testNode.Events[1].Event.ButtonIndex.ShouldBe(button);
         testNode.Events[1].Event.Device.ShouldBe(deviceID);
-        testNode.Events[1].Event.Pressure.ShouldBe(0.0f);
         var timeDiff = testNode.Events[1].DateTime - testNode.Events[0].DateTime;
         timeDiff.TotalSeconds.ShouldBe(seconds, timeTolerance);
         RootNode.RemoveChild(testNode); // Remove immediately since we won't wait a frame for the free

--- a/GodotTestDriver/Input/ControllerInputExtensions.cs
+++ b/GodotTestDriver/Input/ControllerInputExtensions.cs
@@ -46,11 +46,10 @@ public static class ControllerInputExtensions
     /// <param name="seconds">Input duration, in seconds.</param>
     /// <param name="buttonIndex">Button that will be pressed.</param>
     /// <param name="device">Input device that is the source of the event.</param>
-    /// <param name="pressure">Pressure on the button, in the range 0.0f to 1.0f.</param>
     /// <returns>Asynchronous task completed when the button is released.</returns>
-    public static async Task HoldJoypadButtonFor(this Node node, float seconds, JoyButton buttonIndex, int device = 0, float pressure = 1.0f)
+    public static async Task HoldJoypadButtonFor(this Node node, float seconds, JoyButton buttonIndex, int device = 0)
     {
-        node.PressJoypadButton(buttonIndex, device, pressure);
+        node.PressJoypadButton(buttonIndex, device);
         await node.Wait(seconds);
         node.ReleaseJoypadButton(buttonIndex, device);
     }
@@ -66,10 +65,9 @@ public static class ControllerInputExtensions
     /// <param name="node">Node that generates simulated input.</param>
     /// <param name="buttonIndex">Button that will be pressed.</param>
     /// <param name="device">Input device that is the source of the event.</param>
-    /// <param name="pressure">Pressure on the button, in the range 0.0f to 1.0f.</param>
-    public static void TapJoypadButton(this Node node, JoyButton buttonIndex, int device = 0, float pressure = 1.0f)
+    public static void TapJoypadButton(this Node node, JoyButton buttonIndex, int device = 0)
     {
-        node.PressJoypadButton(buttonIndex, device, pressure);
+        node.PressJoypadButton(buttonIndex, device);
         node.ReleaseJoypadButton(buttonIndex, device);
     }
 
@@ -127,14 +125,12 @@ public static class ControllerInputExtensions
     /// <param name="_">Node that generates simulated input.</param>
     /// <param name="buttonIndex">Button that will be pressed.</param>
     /// <param name="device">Input device that is the source of the event.</param>
-    /// <param name="pressure">Pressure on the button, in the range 0.0f to 1.0f.</param>
-    public static void PressJoypadButton(this Node _, JoyButton buttonIndex, int device = 0, float pressure = 1.0f)
+    public static void PressJoypadButton(this Node _, JoyButton buttonIndex, int device = 0)
     {
         var inputEvent = new InputEventJoypadButton
         {
             Pressed = true,
             ButtonIndex = buttonIndex,
-            Pressure = pressure,
             Device = device
         };
         Input.ParseInputEvent(inputEvent);
@@ -157,7 +153,6 @@ public static class ControllerInputExtensions
         {
             Pressed = false,
             ButtonIndex = buttonIndex,
-            Pressure = 0.0f,
             Device = device
         };
         Input.ParseInputEvent(inputEvent);


### PR DESCRIPTION
Godot [has deprecated the Pressure property](https://docs.godotengine.org/en/4.2/classes/class_inputeventjoypadbutton.html#class-inputeventjoypadbutton-property-pressure) of joypad button events. This change removes it from driver methods.

BREAKING CHANGE: Joypad button extension methods no longer have a "pressure" parameter.